### PR TITLE
fix: fixes 403 when using proxy auth

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -189,8 +189,8 @@ def reconnect():
 
 
 @admi.route("/ajax/updateThumbnails", methods=['POST'])
-@admin_required
 @user_login_required
+@admin_required
 def update_thumbnails():
     content = config.get_scheduled_task_settings()
     if content['schedule_generate_book_covers']:


### PR DESCRIPTION
Resolves a 403 response when accessing /ajax/updateThumbnails from a session authenticated by reverse proxy.

For some reason, the decorators are swapped on this route specifically, but not the others. This brings the ordering to be consistent with other routes. The login check should happen before the auth check now.